### PR TITLE
Allow openings to start from tps positions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,14 @@ use std::{io, process, result};
 
 use crate::cli::CliOptions;
 use crate::engine::EngineBuilder;
+use crate::openings::Opening;
 use crate::pgn_writer::PgnWriter;
 use crate::tournament::{Tournament, TournamentSettings};
 use fern::InitError;
 use log::error;
 use std::fs;
 use std::sync::Mutex;
-use tiltak::position::{Move, Position, Settings};
+use tiltak::position::{Position, Settings};
 
 mod cli;
 mod engine;
@@ -25,21 +26,6 @@ fn main() -> Result<()> {
     let cli_args = cli::parse_cli_arguments();
     println!("CLI args: {:?}", cli_args);
 
-    let openings = match &cli_args.book_path {
-        Some(path) => {
-            println!("Loading opening book");
-            match cli_args.size {
-                4 => openings::openings_from_file::<4>(path),
-                5 => openings::openings_from_file::<5>(path),
-                6 => openings::openings_from_file::<6>(path),
-                7 => openings::openings_from_file::<7>(path),
-                8 => openings::openings_from_file::<8>(path),
-                s => panic!("Size {} not supported", s),
-            }?
-        }
-        None => vec![vec![]],
-    };
-
     if let Some(log_file_name) = &cli_args.log_file_name.as_ref() {
         setup_logger(log_file_name).map_err(|err| match err {
             InitError::Io(io_err) => io_err,
@@ -48,15 +34,40 @@ fn main() -> Result<()> {
     }
 
     match cli_args.size {
-        4 => run_match::<4>(openings, cli_args),
-        5 => run_match::<5>(openings, cli_args),
-        6 => run_match::<6>(openings, cli_args),
-        7 => run_match::<7>(openings, cli_args),
-        8 => run_match::<8>(openings, cli_args),
+        4 => {
+            let openings = get_openings(cli_args.book_path.as_ref());
+            run_match::<4>(openings, cli_args)
+        }
+        5 => {
+            let openings = get_openings(cli_args.book_path.as_ref());
+            run_match::<5>(openings, cli_args)
+        }
+        6 => {
+            let openings = get_openings(cli_args.book_path.as_ref());
+            run_match::<6>(openings, cli_args)
+        }
+        7 => {
+            let openings = get_openings(cli_args.book_path.as_ref());
+            run_match::<7>(openings, cli_args)
+        }
+        8 => {
+            let openings = get_openings(cli_args.book_path.as_ref());
+            run_match::<8>(openings, cli_args)
+        }
         s => panic!("Size {} not supported", s),
     }
 
     Ok(())
+}
+
+fn get_openings<const S: usize>(path: Option<&String>) -> Vec<Opening<Position<S>>> {
+    assert!(S > 3 && S <= 8);
+    println!("Loading opening book");
+    if let Some(path) = path {
+        openings::openings_from_file::<Position<S>>(path).expect("Valid")
+    } else {
+        vec![crate::openings::Opening::default()]
+    }
 }
 
 fn setup_logger(file_name: &str) -> result::Result<(), fern::InitError> {
@@ -76,7 +87,7 @@ fn setup_logger(file_name: &str) -> result::Result<(), fern::InitError> {
     Ok(())
 }
 
-fn run_match<const S: usize>(openings: Vec<Vec<Move>>, cli_args: CliOptions) {
+fn run_match<const S: usize>(openings: Vec<Opening<Position<S>>>, cli_args: CliOptions) {
     let desired_uci_options = vec![(
         "HalfKomi".to_string(),
         cli_args.komi.half_komi().to_string(),

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -1,6 +1,7 @@
 use crate::engine::{Engine, EngineBuilder};
 use crate::exit_with_error;
 use crate::game::ScheduledGame;
+use crate::openings::Opening;
 use crate::pgn_writer::PgnWriter;
 use board_game_traits::GameResult::*;
 use pgn_traits::PgnPosition;
@@ -17,7 +18,7 @@ pub struct TournamentSettings<B: PgnPosition> {
     pub time: Duration,
     pub increment: Duration,
     pub num_games: usize,
-    pub openings: Vec<Vec<B::Move>>,
+    pub openings: Vec<Opening<B>>,
     pub pgn_writer: Mutex<PgnWriter<B>>,
 }
 


### PR DESCRIPTION
The current syntax I've chosen somewhat arbitrarily is to separate tps from moves with a semicolon.

The format is therefore [tps];[moves]. When there is no semicolon present in the line then it parses the line in the original way. The opening is represented by an enum so it can support mixing tps start positions with standard openings. 