### PR TITLE
SPRT

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use clap::{self, Arg, ArgAction, Command};
 use std::{env, ffi::OsString, num::NonZeroUsize, process, time::Duration};
 use tiltak::position::Komi;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CliOptions {
     pub size: usize,
     pub concurrency: usize,
@@ -21,6 +21,7 @@ pub struct CliOptions {
     pub log_file_name: Option<String>,
     pub komi: Komi,
     pub tournament_type: TournamentType,
+    pub sprt: Option<CliSprt>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,6 +31,14 @@ pub struct CliEngine {
     pub time: Duration,
     pub increment: Duration,
     pub tei_settings: Vec<(String, String)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CliSprt {
+    pub elo0: f32,
+    pub elo1: f32,
+    pub alpha: f32,
+    pub beta: f32,
 }
 
 pub fn parse_cli_arguments() -> CliOptions {
@@ -147,6 +156,12 @@ pub fn parse_cli_arguments_from(
             .default_value("round-robin")
             .value_parser(clap::builder::PossibleValuesParser::new(["gauntlet", "round-robin", "book-test"]))
         )
+        .arg(Arg::new("sprt-flag")
+            .long("sprt")
+            .help("Perform a sequential probability ratio test.")
+            .value_name("options")
+            .num_args(0..)
+            .action(ArgAction::Append))
         .try_get_matches_from(itr)?;
 
     let engines: Vec<CliEngine> = matches
@@ -303,6 +318,80 @@ pub fn parse_cli_arguments_from(
         s => panic!("Unsupported book format {}", s),
     };
 
+    let mut sprt = None;
+    let sprt_options = matches.get_many::<String>("sprt-flag");
+    if let Some(sprt_options) = sprt_options {
+        let mut elo0 = None;
+        let mut elo1 = None;
+        let mut alpha = None;
+        let mut beta = None;
+
+        for option in sprt_options {
+            if let Some((arg, value)) = option.split_once('=') {
+                match arg {
+                    "elo0" if elo0.is_some() => panic!("Duplicate elo0 arguments \"{}\" and \"{}\" for sprt", elo0.unwrap(), value),
+                    "elo0" => elo0 = Some(value),
+                    "elo1" if elo1.is_some() => panic!("Duplicate elo1 arguments \"{}\" and \"{}\" for sprt", elo1.unwrap(), value),
+                    "elo1" => elo1 = Some(value),
+                    "alpha" if alpha.is_some() => panic!("Duplicate alpha arguments \"{}\" and \"{}\" for sprt", alpha.unwrap(), value),
+                    "alpha" => alpha = Some(value),
+                    "beta" if beta.is_some() => panic!("Duplicate beta arguments \"{}\" and \"{}\" for sprt", beta.unwrap(), value),
+                    "beta" => beta = Some(value),
+                    _ => {
+                        eprintln!("Error: unknown argument {} for sprt", option);
+                        process::exit(1)
+                    }
+                }
+            } else {
+                eprintln!("Error: Expected key=val, found {}", option);
+                process::exit(1)
+            }
+        }
+
+        let Some(elo0) = elo0 else {
+            eprintln!("Error: Missing elo0 for sprt");
+            process::exit(1)
+        };
+        let Some(elo1) = elo1 else {
+            eprintln!("Error: Missing elo1 for sprt");
+            process::exit(1)
+        };
+        let alpha = alpha.unwrap_or("0.05");
+        let beta = beta.unwrap_or("0.05");
+
+        let elo0 = elo0.parse::<f32>().unwrap_or_else(|err| {
+            eprintln!("{} for sprt elo0", err);
+            process::exit(1)
+        });
+        let elo1 = elo1.parse::<f32>().unwrap_or_else(|err| {
+            eprintln!("{} for sprt elo1", err);
+            process::exit(1)
+        });
+        let alpha = alpha.parse::<f32>().unwrap_or_else(|err| {
+            eprintln!("{} for sprt alpha", err);
+            process::exit(1)
+        });
+        let beta = beta.parse::<f32>().unwrap_or_else(|err| {
+            eprintln!("{} for sprt beta", err);
+            process::exit(1)
+        });
+
+        if elo0 >= elo1 {
+            eprintln!("elo1 ({}) must be greater than elo0 ({})", elo1, elo0);
+            process::exit(1)
+        }
+        if alpha <= 0.0 || alpha >= 0.5 {
+            eprintln!("invalid value {} for sprt alpha", alpha);
+            process::exit(1)
+        }
+        if beta <= 0.0 || beta >= 0.5 {
+            eprintln!("invalid value {} for sprt beta", beta);
+            process::exit(1)
+        }
+
+        sprt = Some(CliSprt{ elo0, elo1, alpha, beta });
+    }
+
     Ok(CliOptions {
         size: *matches.get_one::<u64>("size").unwrap() as usize,
         concurrency: *matches.get_one::<u64>("concurrency").unwrap() as usize,
@@ -316,5 +405,6 @@ pub fn parse_cli_arguments_from(
         log_file_name: matches.get_one::<String>("log").cloned(),
         komi: *matches.get_one::<Komi>("komi").unwrap(),
         tournament_type,
+        sprt,
     })
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::{
     openings::{self, BookFormat},
+    sprt::SprtParameters,
     tournament::TournamentType,
     uci::parser,
 };
@@ -21,7 +22,7 @@ pub struct CliOptions {
     pub log_file_name: Option<String>,
     pub komi: Komi,
     pub tournament_type: TournamentType,
-    pub sprt: Option<CliSprt>,
+    pub sprt: Option<SprtParameters>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,14 +32,6 @@ pub struct CliEngine {
     pub time: Duration,
     pub increment: Duration,
     pub tei_settings: Vec<(String, String)>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct CliSprt {
-    pub elo0: f32,
-    pub elo1: f32,
-    pub alpha: f32,
-    pub beta: f32,
 }
 
 pub fn parse_cli_arguments() -> CliOptions {
@@ -373,19 +366,19 @@ pub fn parse_cli_arguments_from(
         let alpha = alpha.unwrap_or("0.05");
         let beta = beta.unwrap_or("0.05");
 
-        let elo0 = elo0.parse::<f32>().unwrap_or_else(|err| {
+        let elo0 = elo0.parse::<f64>().unwrap_or_else(|err| {
             eprintln!("{} for sprt elo0", err);
             process::exit(1)
         });
-        let elo1 = elo1.parse::<f32>().unwrap_or_else(|err| {
+        let elo1 = elo1.parse::<f64>().unwrap_or_else(|err| {
             eprintln!("{} for sprt elo1", err);
             process::exit(1)
         });
-        let alpha = alpha.parse::<f32>().unwrap_or_else(|err| {
+        let alpha = alpha.parse::<f64>().unwrap_or_else(|err| {
             eprintln!("{} for sprt alpha", err);
             process::exit(1)
         });
-        let beta = beta.parse::<f32>().unwrap_or_else(|err| {
+        let beta = beta.parse::<f64>().unwrap_or_else(|err| {
             eprintln!("{} for sprt beta", err);
             process::exit(1)
         });
@@ -403,7 +396,7 @@ pub fn parse_cli_arguments_from(
             process::exit(1)
         }
 
-        sprt = Some(CliSprt{ elo0, elo1, alpha, beta });
+        sprt = Some(SprtParameters::new(elo0, elo1, alpha, beta));
     }
 
     Ok(CliOptions {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,7 +323,10 @@ pub fn parse_cli_arguments_from(
         match tournament_type {
             TournamentType::Sprt => {}
             _ => {
-                eprintln!("Error: sprt option present but tournament type is {:?}", tournament_type);
+                eprintln!(
+                    "Error: sprt option present but tournament type is {:?}",
+                    tournament_type
+                );
                 process::exit(1);
             }
         }
@@ -336,13 +339,29 @@ pub fn parse_cli_arguments_from(
         for option in sprt_options {
             if let Some((arg, value)) = option.split_once('=') {
                 match arg {
-                    "elo0" if elo0.is_some() => panic!("Duplicate elo0 arguments \"{}\" and \"{}\" for sprt", elo0.unwrap(), value),
+                    "elo0" if elo0.is_some() => panic!(
+                        "Duplicate elo0 arguments \"{}\" and \"{}\" for sprt",
+                        elo0.unwrap(),
+                        value
+                    ),
                     "elo0" => elo0 = Some(value),
-                    "elo1" if elo1.is_some() => panic!("Duplicate elo1 arguments \"{}\" and \"{}\" for sprt", elo1.unwrap(), value),
+                    "elo1" if elo1.is_some() => panic!(
+                        "Duplicate elo1 arguments \"{}\" and \"{}\" for sprt",
+                        elo1.unwrap(),
+                        value
+                    ),
                     "elo1" => elo1 = Some(value),
-                    "alpha" if alpha.is_some() => panic!("Duplicate alpha arguments \"{}\" and \"{}\" for sprt", alpha.unwrap(), value),
+                    "alpha" if alpha.is_some() => panic!(
+                        "Duplicate alpha arguments \"{}\" and \"{}\" for sprt",
+                        alpha.unwrap(),
+                        value
+                    ),
                     "alpha" => alpha = Some(value),
-                    "beta" if beta.is_some() => panic!("Duplicate beta arguments \"{}\" and \"{}\" for sprt", beta.unwrap(), value),
+                    "beta" if beta.is_some() => panic!(
+                        "Duplicate beta arguments \"{}\" and \"{}\" for sprt",
+                        beta.unwrap(),
+                        value
+                    ),
                     "beta" => beta = Some(value),
                     _ => {
                         eprintln!("Error: unknown argument {} for sprt", option);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,7 +154,7 @@ pub fn parse_cli_arguments_from(
             .num_args(1)
             .allow_hyphen_values(true)
             .default_value("round-robin")
-            .value_parser(clap::builder::PossibleValuesParser::new(["gauntlet", "round-robin", "book-test"]))
+            .value_parser(clap::builder::PossibleValuesParser::new(["gauntlet", "round-robin", "book-test", "sprt"]))
         )
         .arg(Arg::new("sprt-flag")
             .long("sprt")
@@ -293,6 +293,11 @@ pub fn parse_cli_arguments_from(
             eprintln!("Error: Got {} engines, at least 1 is required", n);
             process::exit(1);
         }
+        ("sprt", 2) => TournamentType::Sprt,
+        ("sprt", n) => {
+            eprintln!("Error: Got {} engines, require exactly 2", n);
+            process::exit(1);
+        }
         (s, _) => panic!("Unsupported tournament format {}", s),
     };
 
@@ -303,6 +308,7 @@ pub fn parse_cli_arguments_from(
             TournamentType::Gauntlet(_) => "gauntlet",
             TournamentType::RoundRobin(_) => "round robin",
             TournamentType::BookTest(_) => "book-test",
+            TournamentType::Sprt => "sprt",
         };
         eprintln!(
             "Warning: The tournament will not give all engines an equal number of white and black games.\nFor a {} tournament with {} engines, the total number of games should be divisible by {}",
@@ -321,6 +327,14 @@ pub fn parse_cli_arguments_from(
     let mut sprt = None;
     let sprt_options = matches.get_many::<String>("sprt-flag");
     if let Some(sprt_options) = sprt_options {
+        match tournament_type {
+            TournamentType::Sprt => {}
+            _ => {
+                eprintln!("Error: sprt option present but tournament type is {:?}", tournament_type);
+                process::exit(1);
+            }
+        }
+
         let mut elo0 = None;
         let mut elo1 = None;
         let mut alpha = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,7 @@ fn run_match<const S: usize>(
         num_games: cli_args.games,
         pgn_writer: Mutex::new(pgnout),
         tournament_type: cli_args.tournament_type,
+        sprt: cli_args.sprt,
     };
 
     let tournament = Tournament::new(settings);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod game;
 mod openings;
 mod pgn_writer;
 mod simulation;
+mod sprt;
 #[cfg(test)]
 mod tests;
 mod tournament;

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -29,7 +29,14 @@ impl SprtParameters {
         let upper_bound = f64::ln((1.0 - beta) / alpha);
         let t0 = elo0 / c_et;
         let t1 = elo1 / c_et;
-        SprtParameters{ lower_bound, upper_bound, elo0, elo1, t0, t1 }
+        SprtParameters {
+            lower_bound,
+            upper_bound,
+            elo0,
+            elo1,
+            t0,
+            t1,
+        }
     }
 
     pub fn llr_bounds(self: SprtParameters) -> (f64, f64) {
@@ -65,14 +72,26 @@ impl PentanomialResult {
         let zeros = penta.iter().filter(|&x| *x == 0.0).count();
         let regularisation = if zeros > 0 { 2.0 / zeros as f64 } else { 0.0 };
         let n: f64 = penta.iter().sum();
-        (n, penta.iter().map(|x| (x + regularisation) / n).collect::<Vec<_>>().try_into().unwrap())
+        (
+            n,
+            penta
+                .iter()
+                .map(|x| (x + regularisation) / n)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        )
     }
 
     pub fn to_mean_and_variance(self: PentanomialResult) -> (f64, f64, f64) {
         let scores = [0.0, 0.25, 0.5, 0.75, 1.0];
         let (n, pdf) = self.to_pdf();
         let mean: f64 = pdf.iter().zip(scores).map(|(p, s)| p * s).sum();
-        let variance: f64 = pdf.iter().zip(scores).map(|(p, s)| p * (s - mean).powf(2.0)).sum();
+        let variance: f64 = pdf
+            .iter()
+            .zip(scores)
+            .map(|(p, s)| p * (s - mean).powf(2.0))
+            .sum();
         (n, mean, variance)
     }
 }

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-// This is an implementation of GSPRT under a pentanominal model.
+// This is an implementation of GSPRT under a pentanomial model.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PentanomialResult {

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -18,19 +18,44 @@ pub struct SprtParameters {
     upper_bound: f64,
     elo0: f64,
     elo1: f64,
+    t0: f64,
+    t1: f64,
 }
 
 impl SprtParameters {
     pub fn new(elo0: f64, elo1: f64, alpha: f64, beta: f64) -> SprtParameters {
-        let lower_bound = (beta / (1.0 - alpha)).ln();
-        let upper_bound = ((1.0 - beta) / alpha).ln();
-        SprtParameters{ lower_bound, upper_bound, elo0, elo1 }
+        let c_et = 800.0 / f64::ln(10.0);
+        let lower_bound = f64::ln(beta / (1.0 - alpha));
+        let upper_bound = f64::ln((1.0 - beta) / alpha);
+        let t0 = elo0 / c_et;
+        let t1 = elo1 / c_et;
+        SprtParameters{ lower_bound, upper_bound, elo0, elo1, t0, t1 }
+    }
+
+    pub fn llr_bounds(self: SprtParameters) -> (f64, f64) {
+        (self.lower_bound, self.upper_bound)
+    }
+
+    pub fn elo_bounds(self: SprtParameters) -> (f64, f64) {
+        (self.elo0, self.elo1)
+    }
+
+    // Approximate formula for the log-likelihood ratio for the given pentanomal result.
+    // See section 4.2 of https://archive.org/details/fishtest_mathematics/normalized_elo_practical/
+    // Many thanks to Michel Van den Bergh.
+    pub fn llr(self: SprtParameters, penta: PentanomialResult) -> f64 {
+        let (n, mean, variance) = penta.to_mean_and_variance();
+        let sigma = (2.0 * variance).sqrt();
+        let t = (mean - 0.5) / sigma;
+        let a = 1.0 + (t - self.t0).powf(2.0);
+        let b = 1.0 + (t - self.t1).powf(2.0);
+        n * f64::ln(a / b)
     }
 }
 
 impl PentanomialResult {
     pub fn to_pdf(self: PentanomialResult) -> (f64, [f64; 5]) {
-        let regularize = 1e-5;
+        let regularize = 1e-2;
         let penta = [
             self.ll as f64 + regularize,
             self.dl as f64 + regularize,

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -40,7 +40,7 @@ impl SprtParameters {
         (self.elo0, self.elo1)
     }
 
-    // Approximate formula for the log-likelihood ratio for the given pentanomal result.
+    // Approximate formula for the log-likelihood ratio for the given pentanomial result.
     // See section 4.2 of https://archive.org/details/fishtest_mathematics/normalized_elo_practical/
     // Many thanks to Michel Van den Bergh.
     pub fn llr(self: SprtParameters, penta: PentanomialResult) -> f64 {
@@ -55,16 +55,17 @@ impl SprtParameters {
 
 impl PentanomialResult {
     pub fn to_pdf(self: PentanomialResult) -> (f64, [f64; 5]) {
-        let regularize = 1e-2;
         let penta = [
-            self.ll as f64 + regularize,
-            self.dl as f64 + regularize,
-            self.dd as f64 + self.wl as f64 + regularize,
-            self.wd as f64 + regularize,
-            self.ww as f64 + regularize,
+            self.ll as f64,
+            self.dl as f64,
+            self.dd as f64 + self.wl as f64,
+            self.wd as f64,
+            self.ww as f64,
         ];
+        let zeros = penta.iter().filter(|&x| *x == 0.0).count();
+        let regularisation = if zeros > 0 { 2.0 / zeros as f64 } else { 0.0 };
         let n: f64 = penta.iter().sum();
-        (n, penta.iter().map(|x| x / n).collect::<Vec<_>>().try_into().unwrap())
+        (n, penta.iter().map(|x| (x + regularisation) / n).collect::<Vec<_>>().try_into().unwrap())
     }
 
     pub fn to_mean_and_variance(self: PentanomialResult) -> (f64, f64, f64) {

--- a/src/sprt.rs
+++ b/src/sprt.rs
@@ -1,0 +1,52 @@
+use std::convert::TryInto;
+
+// This is an implementation of GSPRT under a pentanominal model.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PentanomialResult {
+    pub ww: usize,
+    pub wd: usize,
+    pub wl: usize,
+    pub dd: usize,
+    pub dl: usize,
+    pub ll: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SprtParameters {
+    lower_bound: f64,
+    upper_bound: f64,
+    elo0: f64,
+    elo1: f64,
+}
+
+impl SprtParameters {
+    pub fn new(elo0: f64, elo1: f64, alpha: f64, beta: f64) -> SprtParameters {
+        let lower_bound = (beta / (1.0 - alpha)).ln();
+        let upper_bound = ((1.0 - beta) / alpha).ln();
+        SprtParameters{ lower_bound, upper_bound, elo0, elo1 }
+    }
+}
+
+impl PentanomialResult {
+    pub fn to_pdf(self: PentanomialResult) -> (f64, [f64; 5]) {
+        let regularize = 1e-5;
+        let penta = [
+            self.ll as f64 + regularize,
+            self.dl as f64 + regularize,
+            self.dd as f64 + self.wl as f64 + regularize,
+            self.wd as f64 + regularize,
+            self.ww as f64 + regularize,
+        ];
+        let n: f64 = penta.iter().sum();
+        (n, penta.iter().map(|x| x / n).collect::<Vec<_>>().try_into().unwrap())
+    }
+
+    pub fn to_mean_and_variance(self: PentanomialResult) -> (f64, f64, f64) {
+        let scores = [0.0, 0.25, 0.5, 0.75, 1.0];
+        let (n, pdf) = self.to_pdf();
+        let mean: f64 = pdf.iter().zip(scores).map(|(p, s)| p * s).sum();
+        let variance: f64 = pdf.iter().zip(scores).map(|(p, s)| p * (s - mean).powf(2.0)).sum();
+        (n, mean, variance)
+    }
+}

--- a/src/tests/cli_tests.rs
+++ b/src/tests/cli_tests.rs
@@ -49,6 +49,7 @@ fn cli_test() {
         log_file_name: Some("racetrack.log".to_string()),
         komi: Komi::default(),
         tournament_type: TournamentType::RoundRobin(2),
+        sprt: None,
     };
 
     if let Err(err) = &cli_options {
@@ -94,6 +95,7 @@ fn shuffle_book_test() {
         log_file_name: None,
         komi: Komi::from_half_komi(5).unwrap(),
         tournament_type: TournamentType::RoundRobin(2),
+        sprt: None,
     };
 
     if let Err(err) = &cli_options {
@@ -139,6 +141,7 @@ fn asymmetric_tc_test() {
         log_file_name: None,
         komi: Komi::from_half_komi(4).unwrap(),
         tournament_type: TournamentType::RoundRobin(2),
+        sprt: None,
     };
 
     if let Err(err) = &cli_options {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,6 @@
 mod cli_tests;
 mod simulation_tests;
-mod uci_tests;
 mod sprt_tests;
+mod uci_tests;
 
 mod tournament_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod cli_tests;
 mod simulation_tests;
 mod uci_tests;
+mod sprt_tests;
 
 mod tournament_tests;

--- a/src/tests/sprt_tests.rs
+++ b/src/tests/sprt_tests.rs
@@ -10,7 +10,14 @@ fn sprt_threshold_test() {
         (175, 305, 694, 291, 157, 0.0, 10.0, Some(false)),
     ];
     for (ll, dl, wl, wd, ww, elo0, elo1, expected_result) in examples {
-        let penta = PentanomialResult{ ll, dl, wl, wd, ww, dd: 0 };
+        let penta = PentanomialResult {
+            ll,
+            dl,
+            wl,
+            wd,
+            ww,
+            dd: 0,
+        };
         let sprt = SprtParameters::new(elo0, elo1, 0.05, 0.10);
         let llr = sprt.llr(penta);
         let (lower_bound, upper_bound) = sprt.llr_bounds();
@@ -34,7 +41,14 @@ fn sprt_llr_test() {
         (98, 382, 674, 369, 71, -5.0, 0.0, -1.11),
     ];
     for (ll, dl, wl, wd, ww, elo0, elo1, expected_llr) in examples {
-        let penta = PentanomialResult{ ll, dl, wl, wd, ww, dd: 0 };
+        let penta = PentanomialResult {
+            ll,
+            dl,
+            wl,
+            wd,
+            ww,
+            dd: 0,
+        };
         let sprt = SprtParameters::new(elo0, elo1, 0.05, 0.10);
         let llr = sprt.llr(penta);
         let error = f64::abs(llr - expected_llr);

--- a/src/tests/sprt_tests.rs
+++ b/src/tests/sprt_tests.rs
@@ -1,0 +1,43 @@
+use crate::sprt::{PentanomialResult, SprtParameters};
+
+#[test]
+fn sprt_threshold_test() {
+    let examples = [
+        (485, 1923, 2942, 1937, 594, 0.0, 5.0, Some(true)),
+        (261, 739, 2683, 737, 253, -10.0, 0.0, Some(true)),
+        (63, 252, 385, 250, 74, 0.0, 10.0, None),
+        (527, 1007, 1932, 933, 511, 0.0, 5.0, Some(false)),
+        (175, 305, 694, 291, 157, 0.0, 10.0, Some(false)),
+    ];
+    for (ll, dl, wl, wd, ww, elo0, elo1, expected_result) in examples {
+        let penta = PentanomialResult{ ll, dl, wl, wd, ww, dd: 0 };
+        let sprt = SprtParameters::new(elo0, elo1, 0.05, 0.10);
+        let llr = sprt.llr(penta);
+        let (lower_bound, upper_bound) = sprt.llr_bounds();
+        let result: Option<bool> = if llr <= lower_bound {
+            Some(false)
+        } else if llr >= upper_bound {
+            Some(true)
+        } else {
+            None
+        };
+        assert!(expected_result == result);
+    }
+}
+
+#[test]
+fn sprt_llr_test() {
+    let examples = [
+        (440, 2910, 5170, 2888, 455, 0.0, 5.0, -2.27),
+        (142, 620, 1122, 699, 188, 0.0, 5.0, 2.99),
+        (349, 1561, 3340, 1604, 359, -5.0, 0.0, 2.90),
+        (98, 382, 674, 369, 71, -5.0, 0.0, -1.11),
+    ];
+    for (ll, dl, wl, wd, ww, elo0, elo1, expected_llr) in examples {
+        let penta = PentanomialResult{ ll, dl, wl, wd, ww, dd: 0 };
+        let sprt = SprtParameters::new(elo0, elo1, 0.05, 0.10);
+        let llr = sprt.llr(penta);
+        let error = f64::abs(llr - expected_llr);
+        assert!(error <= 0.01);
+    }
+}

--- a/src/tests/tournament_tests.rs
+++ b/src/tests/tournament_tests.rs
@@ -28,6 +28,7 @@ fn dummy_tournament(
         openings_start_index: 0,
         pgn_writer: Mutex::new(PgnWriter::new(io::empty())),
         tournament_type,
+        sprt: None,
     }
 }
 

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -3,7 +3,7 @@ use crate::game::ScheduledGame;
 use crate::openings::Opening;
 use crate::pgn_writer::PgnWriter;
 use crate::simulation::MatchScore;
-use crate::sprt::PentanomialResult;
+use crate::sprt::{PentanomialResult, SprtParameters};
 use crate::{exit_with_error, simulation};
 use board_game_traits::GameResult::*;
 use pgn_traits::PgnPosition;
@@ -52,6 +52,7 @@ pub struct TournamentSettings<B: PgnPosition> {
     pub openings_start_index: usize,
     pub pgn_writer: Mutex<PgnWriter<B>>,
     pub tournament_type: TournamentType,
+    pub sprt: Option<SprtParameters>,
 }
 
 impl<B: PgnPosition> fmt::Debug for TournamentSettings<B> {
@@ -142,6 +143,7 @@ pub struct Tournament<B: PgnPosition> {
     finished_games: Mutex<Vec<Option<Game<B>>>>,
     pgn_writer: Mutex<PgnWriter<B>>,
     tournament_type: TournamentType,
+    sprt: Option<SprtParameters>,
 }
 
 impl<B> Tournament<B>
@@ -162,6 +164,7 @@ where
             finished_games: Mutex::new(vec![None; settings.num_games]),
             pgn_writer: settings.pgn_writer,
             tournament_type: settings.tournament_type,
+            sprt: settings.sprt,
         }
     }
 
@@ -282,7 +285,7 @@ where
                                 let writer = &thread_tournament.pgn_writer;
                                 writer.lock().unwrap().submit_game(round_number, game);
                             }
-                            thread_tournament.print_score(&engine_names);
+                            thread_tournament.print_score(&engine_names, is_shutting_down);
                         }
                         for engine in worker.engines.iter_mut() {
                             engine.shutdown().unwrap();
@@ -294,10 +297,10 @@ where
         for thread_handle in thread_handles {
             thread_handle.join().unwrap();
         }
-        tournament_arc.print_score(&engine_names);
+        tournament_arc.print_score(&engine_names, is_shutting_down);
     }
 
-    fn print_score(&self, engine_names: &[String]) {
+    fn print_score(&self, engine_names: &[String], is_shutting_down: &'static AtomicBool) {
         let (schedule, finished_games) = loop {
             if let Ok(schedule) = self.games_schedule.try_lock() {
                 if let Ok(finished_games) = self.finished_games.try_lock() {
@@ -418,11 +421,54 @@ where
             }
             TournamentType::BookTest(_) => (),
             TournamentType::Sprt => {
+                println!("Base engine : {}", engine_names[0]);
+                println!("Under test  : {}", engine_names[1]);
+
+                let score = MatchScore {
+                    wins: engine_wins[1][0],
+                    draws: engine_draws[1][0],
+                    losses: engine_losses[1][0],
+                };
+                let full_simulation = simulation::FullWinstonSimulation::run_simulation(score);
+                let lower = full_simulation.result_for_p(0.025);
+                let expected = score.score();
+                let upper = full_simulation.result_for_p(0.975);
+                let lower_elo = simulation::to_elo_string(lower);
+                let expected_elo = simulation::to_elo_string(expected);
+                let upper_elo = simulation::to_elo_string(upper);
+                println!("Elo         : {} [{}, {}] (95%)", expected_elo, lower_elo, upper_elo);
+                println!("WDL         : W: {}, D: {}, L: {}", score.wins, score.draws, score.losses);
+
                 let penta = Self::sprt_penta_stats(&finished_games);
-                print_head_to_head_score(&engine_wins, &engine_draws, engine_names, 0, 1);
-                println!("Penta(0-2): {} {} {} {} {}", penta.ll, penta.dl, penta.dd + penta.wl, penta.wd, penta.ww);
-                println!("{:?}", penta.to_pdf());
-                println!("{:?}", penta.to_mean_and_variance());
+                println!("Penta(0-2)  : {}, {}, {}, {}, {}", penta.ll, penta.dl, penta.dd + penta.wl, penta.wd, penta.ww);
+
+                if let Some(sprt) = self.sprt {
+                    println!("{:?}", penta.to_mean_and_variance());
+
+                    let (elo0, elo1) = sprt.elo_bounds();
+                    let (lower_bound, upper_bound) = sprt.llr_bounds();
+                    let llr = sprt.llr(penta);
+
+                    let meet = if llr <= lower_bound {
+                        format!("(<= {:.2})", lower_bound)
+                    } else if llr >= upper_bound {
+                        format!("(>= {:.2})", upper_bound)
+                    } else {
+                        "".to_string()
+                    };
+                    println!("LLR         : {:.2} {:10} [{:.2} {:.2}]", llr, meet, elo0, elo1);
+
+                    if llr <= lower_bound || llr >= upper_bound {
+                        is_shutting_down.store(true, atomic::Ordering::SeqCst);
+                    }
+
+                    if llr <= lower_bound {
+                        println!("SPRT failed");
+                    }
+                    if llr >= upper_bound {
+                        println!("SPRT passed");
+                    }
+                }
             },
         }
     }
@@ -430,21 +476,21 @@ where
     fn sprt_penta_stats(finished_games: &Vec<Option<Game<B>>>) -> PentanomialResult {
         let mut result = PentanomialResult{ ww: 0, wd: 0, wl: 0, dd: 0, dl: 0, ll: 0 };
         for game_pair in finished_games
-            .windows(2)
+            .chunks(2)
             .filter(|p| p.iter().all(|g| g.is_some()))
         {
             let result1 = game_pair[0].clone().unwrap().game_result().unwrap_or(Draw);
             let result2 = game_pair[1].clone().unwrap().game_result().unwrap_or(Draw);
             match (result1, result2) {
-                (WhiteWin, BlackWin) => result.ww += 1,
-                (WhiteWin, Draw) => result.wd += 1,
-                (Draw, BlackWin) => result.wd += 1,
+                (WhiteWin, BlackWin) => result.ll += 1,
+                (WhiteWin, Draw) => result.dl += 1,
+                (Draw, BlackWin) => result.dl += 1,
                 (WhiteWin, WhiteWin) => result.wl += 1,
                 (BlackWin, BlackWin) => result.wl += 1,
                 (Draw, Draw) => result.dd += 1,
-                (BlackWin, Draw) => result.wl += 1,
-                (Draw, WhiteWin) => result.wl += 1,
-                (BlackWin, WhiteWin) => result.ll += 1,
+                (BlackWin, Draw) => result.wd += 1,
+                (Draw, WhiteWin) => result.wd += 1,
+                (BlackWin, WhiteWin) => result.ww += 1,
             }
         }
         result

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -18,6 +18,7 @@ pub enum TournamentType {
     Gauntlet(NonZeroUsize),
     RoundRobin(usize),
     BookTest(usize),
+    Sprt,
 }
 
 impl TournamentType {
@@ -26,6 +27,7 @@ impl TournamentType {
             TournamentType::Gauntlet(num_challengers) => num_challengers.get() + 1,
             TournamentType::RoundRobin(num_engines) => num_engines,
             TournamentType::BookTest(num_engines) => num_engines,
+            TournamentType::Sprt => 2,
         }
     }
 
@@ -35,6 +37,7 @@ impl TournamentType {
             TournamentType::Gauntlet(num_challengers) => num_challengers.get() * 2,
             TournamentType::RoundRobin(num_engines) => num_engines * (num_engines - 1),
             TournamentType::BookTest(num_engines) => num_engines * num_engines,
+            TournamentType::Sprt => 2,
         }
     }
 }
@@ -110,6 +113,7 @@ impl<B: PgnPosition + Clone> TournamentSettings<B> {
                     size: self.size,
                 })
                 .collect(),
+            TournamentType::Sprt => todo!(),
         }
     }
 }
@@ -404,6 +408,7 @@ where
                 }
             }
             TournamentType::BookTest(_) => (),
+            TournamentType::Sprt => todo!(),
         }
     }
 

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -443,8 +443,6 @@ where
                 println!("Penta(0-2)  : {}, {}, {}, {}, {}", penta.ll, penta.dl, penta.dd + penta.wl, penta.wd, penta.ww);
 
                 if let Some(sprt) = self.sprt {
-                    println!("{:?}", penta.to_mean_and_variance());
-
                     let (elo0, elo1) = sprt.elo_bounds();
                     let (lower_bound, upper_bound) = sprt.llr_bounds();
                     let llr = sprt.llr(penta);

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -113,7 +113,15 @@ impl<B: PgnPosition + Clone> TournamentSettings<B> {
                     size: self.size,
                 })
                 .collect(),
-            TournamentType::Sprt => todo!(),
+            TournamentType::Sprt => (0..self.num_games)
+                .map(|round_number| ScheduledGame {
+                    round_number,
+                    opening: self.openings[(self.openings_start_index + round_number / 2) % self.openings.len()].clone(),
+                    white_engine_id: EngineId(round_number % 2),
+                    black_engine_id: EngineId((round_number + 1) % 2),
+                    size: self.size,
+                })
+                .collect(),
         }
     }
 }

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -118,7 +118,9 @@ impl<B: PgnPosition + Clone> TournamentSettings<B> {
             TournamentType::Sprt => (0..self.num_games)
                 .map(|round_number| ScheduledGame {
                     round_number,
-                    opening: self.openings[(self.openings_start_index + round_number / 2) % self.openings.len()].clone(),
+                    opening: self.openings
+                        [(self.openings_start_index + round_number / 2) % self.openings.len()]
+                    .clone(),
                     white_engine_id: EngineId(round_number % 2),
                     black_engine_id: EngineId((round_number + 1) % 2),
                     size: self.size,
@@ -436,11 +438,24 @@ where
                 let lower_elo = simulation::to_elo_string(lower);
                 let expected_elo = simulation::to_elo_string(expected);
                 let upper_elo = simulation::to_elo_string(upper);
-                println!("Elo         : {} [{}, {}] (95%)", expected_elo, lower_elo, upper_elo);
-                println!("WDL         : W: {}, D: {}, L: {}", score.wins, score.draws, score.losses);
+                println!(
+                    "Elo         : {} [{}, {}] (95%)",
+                    expected_elo, lower_elo, upper_elo
+                );
+                println!(
+                    "WDL         : W: {}, D: {}, L: {}",
+                    score.wins, score.draws, score.losses
+                );
 
                 let penta = Self::sprt_penta_stats(&finished_games);
-                println!("Penta(0-2)  : {}, {}, {}, {}, {}", penta.ll, penta.dl, penta.dd + penta.wl, penta.wd, penta.ww);
+                println!(
+                    "Penta(0-2)  : {}, {}, {}, {}, {}",
+                    penta.ll,
+                    penta.dl,
+                    penta.dd + penta.wl,
+                    penta.wd,
+                    penta.ww
+                );
 
                 if let Some(sprt) = self.sprt {
                     let (elo0, elo1) = sprt.elo_bounds();
@@ -454,7 +469,10 @@ where
                     } else {
                         "".to_string()
                     };
-                    println!("LLR         : {:.2} {:10} [{:.2} {:.2}]", llr, meet, elo0, elo1);
+                    println!(
+                        "LLR         : {:.2} {:10} [{:.2} {:.2}]",
+                        llr, meet, elo0, elo1
+                    );
 
                     if llr <= lower_bound || llr >= upper_bound {
                         is_shutting_down.store(true, atomic::Ordering::SeqCst);
@@ -467,12 +485,19 @@ where
                         println!("SPRT passed");
                     }
                 }
-            },
+            }
         }
     }
 
     fn sprt_penta_stats(finished_games: &Vec<Option<Game<B>>>) -> PentanomialResult {
-        let mut result = PentanomialResult{ ww: 0, wd: 0, wl: 0, dd: 0, dl: 0, ll: 0 };
+        let mut result = PentanomialResult {
+            ww: 0,
+            wd: 0,
+            wl: 0,
+            dd: 0,
+            dl: 0,
+            ll: 0,
+        };
         for game_pair in finished_games
             .chunks(2)
             .filter(|p| p.iter().all(|g| g.is_some()))

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -421,7 +421,8 @@ where
                 let penta = Self::sprt_penta_stats(&finished_games);
                 print_head_to_head_score(&engine_wins, &engine_draws, engine_names, 0, 1);
                 println!("Penta(0-2): {} {} {} {} {}", penta.ll, penta.dl, penta.dd + penta.wl, penta.wd, penta.ww);
-                println!("{:?}", penta.to_pdf())
+                println!("{:?}", penta.to_pdf());
+                println!("{:?}", penta.to_mean_and_variance());
             },
         }
     }


### PR DESCRIPTION
This PR implements pentanomial GSPRT support.

## Example output

Note that [-50 0] in the example are not usual bounds one would use, but were chosen so the test would terminate quickly for this example.

```
Played 95 games. 42 white wins, 53 black wins, 0 draws.
Base engine : ./tak-base
Under test  : ./tak-dev
Elo         : +33 [-40, +105] (95%)
WDL         : W: 52, D: 0, L: 43
Penta(0-2)  : 10, 0, 22, 0, 15
LLR         : 3.37 (>= 2.94)  [-50.00 0.00]
SPRT passed
```

## Command line parameters

Example:

```
racetrack --games 10000 --engine path=./tak-base tc=8+0.08 --engine path=./tak-dev tc=8+0.08 --sprt elo0=-10 elo1=0 --format sprt --concurrency 14
```

There is now a new tournament type called "sprt" which is for use for GSPRT testing.

This must also be used with the `--sprt` command line option. This accepts the following parameters:

```
elo0=value   required, lower bound elo
elo1=value   required, upper bound elo
alpha=value  optional, default = 0.05, desired type I (false positive) error rate
beta=value   optional, default = 0.05, desired type II (false negative) error rate
```

The parameter provided to `--games` acts as a hard upper bound to the number of games run.

## Recommended usage

Typical values used in chess engine development:

| elo0  | elo1 | usage reason|
| ------------- | ------------- | ---- |
| 0 | 10 | testing for elo gain |
| 0 | 5 | testing for elo gain (stronger engines) |
| 0 | 2 | testing for elo gain (stockfish) |
| -10 | 0 | testing for elo non-regression |
| -5 | 0 | testing for elo non-regression (stronger engines) |
| -1.75 | 0.25 | testing for elo non-regression (stockfish) |

Values of 0.05 for alpha and beta are typical (5% false positive and false negative rate).