### PR TITLE
Grab an engine's name from an `id name` message, if it sends one.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -83,6 +83,9 @@ impl EngineBuilder {
                 Some("option") => {
                     engine.options.push(parse_option(&input).unwrap()); // TODO: Handle error
                 }
+                _ if input.starts_with("id name") => {
+                    engine.name = input.trim_start_matches("id name").trim().to_owned();
+                }
                 s => info!("Unexpected message \"{}\", ignoring", s.unwrap_or_default()),
             }
         }

--- a/src/tournament.rs
+++ b/src/tournament.rs
@@ -204,11 +204,6 @@ where
         is_shutting_down: &'static AtomicBool,
         engine_builders: &[EngineBuilder],
     ) {
-        let engine_names: Vec<String> = engine_builders
-            .iter()
-            .map(|builder| builder.path.clone())
-            .collect();
-
         // Initialize engines
         println!("Initializing engines");
 
@@ -220,6 +215,13 @@ where
                     .map(|builder| Self::initialize_with_options_or_exit(builder))
                     .collect(),
             })
+            .collect();
+
+        // Take the engine names from the first worker.
+        let engine_names: Vec<String> = workers[0]
+            .engines
+            .iter()
+            .map(|engine| engine.name().to_owned())
             .collect();
 
         let tournament_arc = Arc::new(self);


### PR DESCRIPTION
Figured this might be nicer to look at than a path, if an engine supports sending the `id name <engine name>` message after `teiok`.